### PR TITLE
Zimi integration

### DIFF
--- a/homeassistant/components/zimi/config_flow.py
+++ b/homeassistant/components/zimi/config_flow.py
@@ -5,8 +5,8 @@ import logging
 import socket
 from typing import Any
 
-import voluptuous as vol  # type: ignore[import]
-from zcc import ControlPointDiscoveryService, ControlPointError  # type: ignore[import]
+import voluptuous as vol
+from zcc import ControlPointDiscoveryService, ControlPointError
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT

--- a/homeassistant/components/zimi/controller.py
+++ b/homeassistant/components/zimi/controller.py
@@ -54,7 +54,7 @@ class ZimiController:
     async def connect(self) -> bool:
         """Initialize Connection with the Zimi Controller."""
         try:
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Connecting to %s:%d with verbosity=%s, timeout=%d and watchdog=%d",
                 self.host,
                 self.port,
@@ -73,8 +73,8 @@ class ZimiController:
                 timeout=self.timeout,
             )
             await self.controller.connect()
-            _LOGGER.info("Connected")
-            _LOGGER.info("\n%s", self.controller.describe())
+            _LOGGER.debug("Connected")
+            _LOGGER.debug("\n%s", self.controller.describe())
 
             if self.watchdog > 0:
                 self.controller.start_watchdog(self.watchdog)

--- a/homeassistant/components/zimi/controller.py
+++ b/homeassistant/components/zimi/controller.py
@@ -2,7 +2,7 @@
 import logging
 import pprint
 
-from zcc import (  # type: ignore[import]
+from zcc import (
     ControlPoint,
     ControlPointDescription,
     ControlPointDiscoveryService,
@@ -84,7 +84,6 @@ class ZimiController:
             raise ConfigEntryNotReady(error) from error
 
         if self.controller:
-            # self.hass.config_entries.async_setup_platforms(self.config, PLATFORMS)
             self.hass.data[CONTROLLER] = self
             await self.hass.config_entries.async_forward_entry_setups(
                 self.config, PLATFORMS

--- a/homeassistant/components/zimi/cover.py
+++ b/homeassistant/components/zimi/cover.py
@@ -17,7 +17,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 
-# Import the device class from the component that you want to support
+# Import the device class from the component that you want to support.
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONTROLLER, DOMAIN
@@ -39,7 +39,6 @@ async def async_setup_entry(
 
     entities = []
 
-    # for key, device in controller.api.devices.items():
     for device in controller.controller.doors:
         entities.append(ZimiCover(device, debug=debug))
 
@@ -50,7 +49,7 @@ class ZimiCover(CoverEntity):
     """Representation of a Zimi cover."""
 
     def __init__(self, cover, debug=False) -> None:
-        """Initialize an Zimicover."""
+        """Initialize an Zimi cover."""
 
         if debug:
             _LOGGER.setLevel(logging.DEBUG)

--- a/homeassistant/components/zimi/fan.py
+++ b/homeassistant/components/zimi/fan.py
@@ -10,9 +10,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 
-# Import the device class from the component that you want to support
+# Import the device class from the component that you want to support.
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util.percentage import (
+from homeassistant.util.percentage import (  # type: ignore[attr-defined]
     int_states_in_range,
     percentage_to_ranged_value,
     ranged_value_to_percentage,
@@ -37,7 +37,6 @@ async def async_setup_entry(
 
     entities = []
 
-    # for key, device in controller.api.devices.items():
     for device in controller.controller.fans:
         entities.append(ZimiFan(device, debug=debug))
 
@@ -48,7 +47,7 @@ class ZimiFan(FanEntity):
     """Representation of a Zimi fan."""
 
     def __init__(self, fan, debug=False) -> None:
-        """Initialize an ZimiFan."""
+        """Initialize an Zimi Fan."""
 
         if debug:
             _LOGGER.setLevel(logging.DEBUG)

--- a/homeassistant/components/zimi/light.py
+++ b/homeassistant/components/zimi/light.py
@@ -9,7 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 
-# Import the device class from the component that you want to support
+# Import the device class from the component that you want to support.
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONTROLLER, DOMAIN
@@ -35,7 +35,6 @@ async def async_setup_entry(
 
     entities = []
 
-    # for key, device in controller.api.devices.items():
     for device in controller.controller.lights:
         entities.append(ZimiLight(device, debug=debug))
 

--- a/homeassistant/components/zimi/manifest.json
+++ b/homeassistant/components/zimi/manifest.json
@@ -8,6 +8,7 @@
   "homekit": {},
   "integration_type": "hub",
   "iot_class": "local_push",
+  "loggers": ["zcc-helper"],
   "requirements": ["zcc-helper==3.2.1"],
   "ssdp": [],
   "zeroconf": []

--- a/homeassistant/components/zimi/sensor.py
+++ b/homeassistant/components/zimi/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 
-# Import the device class from the component that you want to support
+# Import the device class from the component that you want to support.
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONTROLLER, DOMAIN

--- a/homeassistant/components/zimi/switch.py
+++ b/homeassistant/components/zimi/switch.py
@@ -9,7 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 
-# Import the device class from the component that you want to support
+# Import the device class from the component that you want to support.
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONTROLLER, DOMAIN
@@ -30,8 +30,6 @@ async def async_setup_entry(
     controller: ZimiController = hass.data[CONTROLLER]
 
     entities = []
-
-    # for key, device in controller.api.devices.items():
     for device in controller.controller.outlets:
         entities.append(ZimiSwitch(device, debug=debug))
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Adding new integration supporting Zimi Cloud devices. Includes support for: 
- Zimi Fans
- Zimi Covers
- Zimi Lights
- Zimi Fans
- Zimi Sensors
- Zimi Switches
- Zimi Cloud Controller

https://zimi.life/
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
